### PR TITLE
🐛 fix: uncraftable potion

### DIFF
--- a/data/game/function/resources/lang/zh_tw.mcfunction
+++ b/data/game/function/resources/lang/zh_tw.mcfunction
@@ -61,14 +61,14 @@ data modify storage game:lang team_picker.red set value "紅隊"
 data modify storage game:lang team_picker.white set value "白隊"
 data modify storage game:lang team_picker.yellow set value "黃隊"
 
-data modify storage game:lang join_team.black set value "你加入了黑隊!"
-data modify storage game:lang join_team.blue set value "你加入了藍隊!"
-data modify storage game:lang join_team.gray set value "你加入了灰隊!"
-data modify storage game:lang join_team.green set value "你加入了綠隊!"
-data modify storage game:lang join_team.orange set value "你加入了橘隊!"
-data modify storage game:lang join_team.red set value "你加入了紅隊!"
-data modify storage game:lang join_team.white set value "你加入了白隊!"
-data modify storage game:lang join_team.yellow set value "你加入了黃隊!"
+data modify storage game:lang join_team.black set value "你加入了黑隊！"
+data modify storage game:lang join_team.blue set value "你加入了藍隊！"
+data modify storage game:lang join_team.gray set value "你加入了灰隊！"
+data modify storage game:lang join_team.green set value "你加入了綠隊！"
+data modify storage game:lang join_team.orange set value "你加入了橘隊！"
+data modify storage game:lang join_team.red set value "你加入了紅隊！"
+data modify storage game:lang join_team.white set value "你加入了白隊！"
+data modify storage game:lang join_team.yellow set value "你加入了黃隊！"
 
 data modify storage game:lang win.black set value {title: "黑隊", subtitle: "贏了！"}
 data modify storage game:lang win.blue set value {title: "藍隊", subtitle: "贏了！"}

--- a/data/game/loot_table/market/rusher.json
+++ b/data/game/loot_table/market/rusher.json
@@ -57,12 +57,12 @@
             {
               "function": "minecraft:set_name",
               "entity": "this",
-              "target": "item_name",
               "name": [
                 {
                   "nbt": "market.rusher",
                   "storage": "game:lang",
-                  "interpret": true
+                  "interpret": true,
+                  "italic": false
                 },
                 {
                   "text": " "

--- a/data/game/loot_table/market/spy.json
+++ b/data/game/loot_table/market/spy.json
@@ -44,9 +44,9 @@
             {
               "function": "minecraft:set_name",
               "entity": "this",
-              "target": "item_name",
               "name": {
-                "translate": "item.minecraft.tipped_arrow"
+                "translate": "item.minecraft.tipped_arrow",
+                "italic": false
               }
             },
             {
@@ -97,11 +97,11 @@
             {
               "function": "minecraft:set_name",
               "entity": "this",
-              "target": "item_name",
               "name": [
                 {
                   "nbt": "market.spy",
                   "storage": "game:lang",
+                  "italic": false,
                   "interpret": true
                 },
                 {
@@ -156,11 +156,11 @@
             {
               "function": "minecraft:set_name",
               "entity": "this",
-              "target": "item_name",
               "name": [
                 {
                   "nbt": "market.spy",
                   "storage": "game:lang",
+                  "italic": false,
                   "interpret": true
                 },
                 {

--- a/data/game/loot_table/market/swordsman.json
+++ b/data/game/loot_table/market/swordsman.json
@@ -81,11 +81,11 @@
             {
               "function": "minecraft:set_name",
               "entity": "this",
-              "target": "item_name",
               "name": [
                 {
                   "nbt": "market.swordsman",
                   "storage": "game:lang",
+                  "italic": false,
                   "interpret": true
                 },
                 {


### PR DESCRIPTION
`item_name` now has priority lower than `potion_contents`. Hence, using `item_name` on a custom potion will result "Uncraftable Potion / Potions irréalisables / 不可合成的藥水". So I changed it to `custom_name`.
Before:
```json
{
  "target": "item_name",
  "name": [
    {
      "nbt": "market.swordsman",
      "storage": "game:lang",
      "interpret": true
    },
    {"text": " "}, {"translate": "item.minecraft.potion"}
  ]
}
```
After:
```json
{
  "name": [
    {
      "nbt": "market.swordsman",
      "storage": "game:lang",
      "italic": false,
      "interpret": true
    },
    {"text": " "}, {"translate": "item.minecraft.potion"}
  ]
}
```

On the other hand, maybe` item_name` can be considered using on firework rockets. And also make it translatable.